### PR TITLE
[DATAVIC-220] Data.Vic (Search) - Unable to deselect Category field after making a search

### DIFF
--- a/ckanext/datavic_odp_theme/templates/snippets/dataset_search_form.html
+++ b/ckanext/datavic_odp_theme/templates/snippets/dataset_search_form.html
@@ -118,7 +118,7 @@
                                     <div class="rpl-checklist__list-row rpl-checklist__list-row--single">
                                       <button type="button" class="rpl-checklist__single-item default"
                                               data-value=""
-                                              data-target="group"
+                                              data-target="groups"
                                               data-checklist="checklist-group"
                                       >
                                         <span>Please select a category</span>


### PR DESCRIPTION
Fixed issue with 'Please select a category' data-target setting the wrong id
data-target="group" should be data-target="groups"