### PR TITLE
[DATAVIC-343] - updated package read and resource read

### DIFF
--- a/ckanext/datavic_odp_theme/templates/package/resource_read.html
+++ b/ckanext/datavic_odp_theme/templates/package/resource_read.html
@@ -1,6 +1,38 @@
 {% ckan_extends %}
 
 
+{% block resource_content %}
+  {% block package_archive_notice %}
+    {% if is_activity_archive %}
+      <div id="activity-archive-notice" class="alert alert-danger">
+        {% trans url=h.url_for(pkg.type ~ '.read', id=pkg.id) %}
+        You're currently viewing an old version of this dataset. To see the
+        current version, click <a href="{{ url }}">here</a>.
+        {% endtrans %}
+      </div>
+    {% endif %}
+  {% endblock %}
+  {% block resource_read_title %}<h1 class="page-heading">{{ h.resource_display_name(res) | truncate(50) }}</h1>{% endblock %}
+  {% block resource_read_url %}
+    {% if res.url and h.is_url(res.url) %}
+      <p class="text-muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
+    {% elif res.url %}
+      <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
+    {% endif %}
+  {% endblock %}
+
+  <div class="prose notes" property="rdfs:label">
+    {% if res.description %}
+      {{ h.render_markdown(res.description) }}
+    {% endif %}
+    {% if not res.description and package.notes %}
+      <h3>{{ _('From the dataset abstract') }}</h3>
+      <blockquote>{{ h.markdown_extract(h.get_translated(package, 'notes')) }}</blockquote>
+      <p>{% trans dataset=package.title, url=h.url_for(package.type ~ '.read', id=package.id if is_activity_archive else package.name) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
+    {% endif %}
+  </div>
+{% endblock %}
+
 {% block primary_content %}
   {% block resource_additional_information %}
     {% if res %}

--- a/ckanext/datavic_odp_theme/templates/package/snippets/additional_info.html
+++ b/ckanext/datavic_odp_theme/templates/package/snippets/additional_info.html
@@ -133,19 +133,6 @@
           </tr>
         {% endif %}
 
-      {% block extras scoped %}
-        {% set hidden = ['harvest_url', 'spatial', 'full_metadata_url'] %}
-        {% for extra in h.sorted_extras(pkg_dict.extras) %}
-          {% set key, value = extra %}
-          {% if key not in hidden %}
-            <tr rel="dc:relation" resource="_:extra{{ i }}">
-              <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
-              <td class="dataset-details" property="rdf:value">{{ value }}</td>
-            </tr>
-          {% endif %}
-        {% endfor %}
-      {% endblock %}
-
       {% endblock %}
     </tbody>
   </table>


### PR DESCRIPTION
https://digital-engagement.atlassian.net/browse/DATAVIC-343

with `{% block resource_content %}` mostly they are just copy from ckan core, the only changes is on line 29. 