### PR TITLE
SXDEDPCXZIC-32_DATAVIC-489 /Datastore refresh times do not seem to be updating

### DIFF
--- a/ckanext/datavic_odp_theme/__init__.py
+++ b/ckanext/datavic_odp_theme/__init__.py
@@ -1,0 +1,10 @@
+from requests import utils
+
+import ckan.plugins.toolkit as tk
+
+DEFAULT_AGENT = utils.default_user_agent()
+CONFIG_AGENT = "ckanext.datavic.odp.user_agent"
+
+# Immitate browser's User-Agent because firewall blocks requests from
+# background jobs with the default User-Agent
+utils.default_user_agent = lambda *a, **k: tk.config.get(CONFIG_AGENT, DEFAULT_AGENT)


### PR DESCRIPTION
Last refresh times are frozen at 2 months ago. When looking into the datastore of separate datasets, it seems they are being refreshed, but this table shows this time.

## Problem

Background jobs service, responsible for updating the *Last refresh* field, is blocked by the firewall of web-node because it just looks like a regular bot.

## Solution

Add the `User-Agent` header so that firewall believes that requests come from the real user.