### PR TITLE
SXDEDPCXZIC-65_DATAVIC-440/updated data and resources header  [dev]

### DIFF
--- a/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
@@ -75,7 +75,7 @@ $rpl-search-form-search-text: $rpl-search-form-show-filters-ruleset !default;
 
   h1 {
     @include rpl_typography_ruleset($rpl-search-form-heading-ruleset);
-    color: $rpl-search-form-heading-color;
+    color: rpl-color('extra_dark_neutral');
     margin-top: 0;
     padding-left: 25px;
 

--- a/ckanext/datavic_odp_theme/templates/package/read_base.html
+++ b/ckanext/datavic_odp_theme/templates/package/read_base.html
@@ -6,7 +6,7 @@
     {{ h.build_nav_icon('dataset.activity', _('Activity Stream'), id=pkg.name, icon=None) }}
   {% endif %}
   {% if h.historical_resources_list(pkg.resources)[1] and h.historical_resources_list(pkg.resources)[1]['period_start'] and h.historical_resources_list(pkg.resources)[1]['period_start'] != 'None' and  h.historical_resources_list(pkg.resources)[1]['period_start'] != ""%}
-    {{ h.build_nav_icon('odp_dataset.historical', _('Historical Data'), id=pkg.name, icon=None) }}
+    {{ h.build_nav_icon('odp_dataset.historical', _('Historical Data and Resources'), id=pkg.name, icon=None) }}
   {% endif %}
 {% endblock %}
 

--- a/ckanext/datavic_odp_theme/templates/package/read_base_historical.html
+++ b/ckanext/datavic_odp_theme/templates/package/read_base_historical.html
@@ -20,7 +20,7 @@
     {{ h.build_nav_icon('dataset.activity', _('Activity Stream'), id=pkg.name, icon=None) }}
   {% endif %}
   {% if h.historical_resources_list(pkg.resources)[1] and  h.historical_resources_list(pkg.resources)[1]['period_start'] != 'None' and  h.historical_resources_list(pkg.resources)[1]['period_start'] != ""%}
-    {{ h.build_nav_icon('odp_dataset.historical', _('Historical Data'), id=pkg.name, icon=None) }}
+    {{ h.build_nav_icon('odp_dataset.historical', _('Historical Data and Resources'), id=pkg.name, icon=None) }}
   {% endif %}
 {% endblock %}
 

--- a/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
+++ b/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
@@ -2156,7 +2156,7 @@ nav {
       padding-top: 3rem;
       padding-bottom: 3.75rem; } }
   .rpl-search-form h1 {
-    color: #0052c2;
+    color: #011a3c;
     margin-top: 0;
     padding-left: 25px; }
     @media screen and (min-width: 0) {


### PR DESCRIPTION
- Change the header to H1 at the top of Dataset History tab container and change text to “Historical Data Resources“ 
- change header text color for dataset search form