### PR TITLE
SXDEDPCXZIC-73_DATAVIC-440/Add further changes to First level heading

### DIFF
--- a/ckanext/datavic_odp_theme/grunt/sass/_font.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_font.scss
@@ -4,6 +4,7 @@ $rpl-font-sizes: (
         'tera': rem(56px),
         'xgiga': rem(48px),
         'giga': rem(36px),
+        'xmega': rem(32px),
         'mega': rem(28px),
         'xl': rem(24px),
         'l': rem(20px),

--- a/ckanext/datavic_odp_theme/grunt/sass/_header.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_header.scss
@@ -252,3 +252,8 @@ $rpl-site-header-logout-btn-icon-margin: 0 0 0 $rpl-space-2 !default;
     }
   }
 }
+
+.module .dashboard-header {
+  font-size: 1.5em;
+  padding: 0px 15px 0px 30px;
+}

--- a/ckanext/datavic_odp_theme/grunt/sass/_header.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_header.scss
@@ -254,6 +254,7 @@ $rpl-site-header-logout-btn-icon-margin: 0 0 0 $rpl-space-2 !default;
 }
 
 .module .dashboard-header {
+  font-family: rpl-font('bold');
   font-size: 1.5em;
   padding: 0px 15px 0px 30px;
 }

--- a/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
@@ -75,7 +75,7 @@ $rpl-search-form-search-text: $rpl-search-form-show-filters-ruleset !default;
 
   h1 {
     @include rpl_typography_ruleset($rpl-search-form-heading-ruleset);
-    color: $rpl-search-form-heading-color;
+    color: rpl-color('extra_dark_neutral');
     margin-top: 0;
     padding-left: 25px;
 

--- a/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
@@ -46,8 +46,8 @@ $rpl-search-form-heading-color: rpl-color('primary') !default;
 $rpl-search-form-dark-text-color: rpl-color('white') !default;
 $rpl-search-form-heading-ruleset: (
         'xs': ('mega', 1.07em, 'bold'),
-        'm': ('xgiga', 1em, 'bold'),
-        'xxl': ('tera', 1em, 'bold')
+        'm': ('xmega', 1em, 'bold'),
+        'xxl': ('xmega', 1em, 'bold')
 ) !default;
 $rpl-search-form-sub-heading-ruleset: (
         'm': ('mega', 1em, 'medium'),

--- a/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
@@ -77,6 +77,7 @@ $rpl-search-form-search-text: $rpl-search-form-show-filters-ruleset !default;
     @include rpl_typography_ruleset($rpl-search-form-heading-ruleset);
     color: $rpl-search-form-heading-color;
     margin-top: 0;
+    padding-left: 25px;
 
     @at-root {
       #{$root}--dark h1 {

--- a/ckanext/datavic_odp_theme/templates/package/read_base.html
+++ b/ckanext/datavic_odp_theme/templates/package/read_base.html
@@ -6,7 +6,7 @@
     {{ h.build_nav_icon('dataset.activity', _('Activity Stream'), id=pkg.name, icon=None) }}
   {% endif %}
   {% if h.historical_resources_list(pkg.resources)[1] and h.historical_resources_list(pkg.resources)[1]['period_start'] and h.historical_resources_list(pkg.resources)[1]['period_start'] != 'None' and  h.historical_resources_list(pkg.resources)[1]['period_start'] != ""%}
-    {{ h.build_nav_icon('odp_dataset.historical', _('Historical Data'), id=pkg.name, icon=None) }}
+    {{ h.build_nav_icon('odp_dataset.historical', _('Historical Data and Resources'), id=pkg.name, icon=None) }}
   {% endif %}
 {% endblock %}
 

--- a/ckanext/datavic_odp_theme/templates/package/read_base_historical.html
+++ b/ckanext/datavic_odp_theme/templates/package/read_base_historical.html
@@ -20,7 +20,7 @@
     {{ h.build_nav_icon('dataset.activity', _('Activity Stream'), id=pkg.name, icon=None) }}
   {% endif %}
   {% if h.historical_resources_list(pkg.resources)[1] and  h.historical_resources_list(pkg.resources)[1]['period_start'] != 'None' and  h.historical_resources_list(pkg.resources)[1]['period_start'] != ""%}
-    {{ h.build_nav_icon('odp_dataset.historical', _('Historical Data'), id=pkg.name, icon=None) }}
+    {{ h.build_nav_icon('odp_dataset.historical', _('Historical Data and Resources'), id=pkg.name, icon=None) }}
   {% endif %}
 {% endblock %}
 

--- a/ckanext/datavic_odp_theme/templates/package/snippets/resources_list.html
+++ b/ckanext/datavic_odp_theme/templates/package/snippets/resources_list.html
@@ -10,7 +10,11 @@ Example:
 
 #}
 <section id="dataset-resources" class="resources">
-  <h2>{{ _('Data and Resources') }}</h2>
+  {% if historical %}
+    <h2>{{ _('Historical Data and Resources') }}</h2>
+  {% else %}
+    <h2>{{ _('Data and Resources') }}</h2>
+  {% endif %}
   {% block resource_list %}
     {% if resources %}
       <ul class="{% block resource_list_class %}resource-list{% endblock %}">

--- a/ckanext/datavic_odp_theme/templates/snippets/dataset_search_form.html
+++ b/ckanext/datavic_odp_theme/templates/snippets/dataset_search_form.html
@@ -7,6 +7,22 @@
 
     <div class="search-form-wrapper">
       <div class="rpl-search-form da-search rpl-site-constrain--on-all">
+      {% if query %}
+        <h1> {{ ungettext(
+            'Search Results ({number} dataset found)', 
+            'Search Results ({number} datasets found)', 
+            count
+            ).format(number=count) }}
+        </h1>              
+      {% else %}
+        <h1>
+          {{ ungettext(
+            'Search {number} open dataset', 
+            'Search {number} open datasets', 
+             count
+          ).format(number=count) }}
+         </h1>
+       {% endif %}
         <form {% if form_id %}id="{{ form_id }}" {% endif %}class="rpl-form" action="{{ h.url_for('search') }}" method="get">
           <input type="hidden" id="field-order-by" name="sort" value="{{ sorting_selected }}" />
           <div class="rpl-search-form__field">

--- a/ckanext/datavic_odp_theme/templates/user/dashboard.html
+++ b/ckanext/datavic_odp_theme/templates/user/dashboard.html
@@ -1,6 +1,7 @@
 {% ckan_extends %}
 
     {% block page_header %}
+      <h1 class="dashboard-header">{{ _('My Dashboard') }}</h1>
       <header class="module-content page-header hug">
         <div class="content_action">
           {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn', icon='cog' %}

--- a/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
+++ b/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
@@ -2156,7 +2156,7 @@ nav {
       padding-top: 3rem;
       padding-bottom: 3.75rem; } }
   .rpl-search-form h1 {
-    color: #0052c2;
+    color: #011a3c;
     margin-top: 0;
     padding-left: 25px; }
     @media screen and (min-width: 0) {

--- a/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
+++ b/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
@@ -1179,6 +1179,10 @@ nav {
     line-height: 1rem;
     padding-left: 0; }
 
+.module .dashboard-header {
+  font-size: 1.5em;
+  padding: 0px 15px 0px 30px; }
+
 .rpl-text-icon--before {
   margin: auto .5rem auto auto; }
 
@@ -2153,7 +2157,8 @@ nav {
       padding-bottom: 3.75rem; } }
   .rpl-search-form h1 {
     color: #0052c2;
-    margin-top: 0; }
+    margin-top: 0;
+    padding-left: 25px; }
     @media screen and (min-width: 0) {
       .rpl-search-form h1 {
         font-family: "VIC-Bold", "Arial", "Helvetica", "sans-serif";

--- a/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
+++ b/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
@@ -1180,6 +1180,7 @@ nav {
     padding-left: 0; }
 
 .module .dashboard-header {
+  font-family: "VIC-Bold", "Arial", "Helvetica", "sans-serif";
   font-size: 1.5em;
   padding: 0px 15px 0px 30px; }
 
@@ -2168,12 +2169,12 @@ nav {
     @media screen and (min-width: 768px) {
       .rpl-search-form h1 {
         font-family: "VIC-Bold", "Arial", "Helvetica", "sans-serif";
-        font-size: 3rem;
+        font-size: 2rem;
         line-height: 1em; } }
     @media screen and (min-width: 1600px) {
       .rpl-search-form h1 {
         font-family: "VIC-Bold", "Arial", "Helvetica", "sans-serif";
-        font-size: 3.5rem;
+        font-size: 2rem;
         line-height: 1em; } }
     .rpl-search-form--dark h1 {
       color: #fff; }


### PR DESCRIPTION
- H1 font size is reduced to 2rem (from the current 3.5rem)
- Dataset Search page title: should read: “Search Y datasets“
- h1 title on “My Dashboard“ page uses VIC-Bold font