### PR TITLE
SXDEDPCXZIC-73_DATAVIC-440/Add further changes to First level heading [DEV]

### DIFF
--- a/ckanext/datavic_odp_theme/grunt/sass/_font.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_font.scss
@@ -4,6 +4,7 @@ $rpl-font-sizes: (
         'tera': rem(56px),
         'xgiga': rem(48px),
         'giga': rem(36px),
+        'xmega': rem(32px),
         'mega': rem(28px),
         'xl': rem(24px),
         'l': rem(20px),

--- a/ckanext/datavic_odp_theme/grunt/sass/_header.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_header.scss
@@ -254,6 +254,7 @@ $rpl-site-header-logout-btn-icon-margin: 0 0 0 $rpl-space-2 !default;
 }
 
 .module .dashboard-header {
+  font-family: rpl-font('bold');
   font-size: 1.5em;
   padding: 0px 15px 0px 30px;
 }

--- a/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
+++ b/ckanext/datavic_odp_theme/grunt/sass/_search_form.scss
@@ -46,8 +46,8 @@ $rpl-search-form-heading-color: rpl-color('primary') !default;
 $rpl-search-form-dark-text-color: rpl-color('white') !default;
 $rpl-search-form-heading-ruleset: (
         'xs': ('mega', 1.07em, 'bold'),
-        'm': ('xgiga', 1em, 'bold'),
-        'xxl': ('tera', 1em, 'bold')
+        'm': ('xmega', 1em, 'bold'),
+        'xxl': ('xmega', 1em, 'bold')
 ) !default;
 $rpl-search-form-sub-heading-ruleset: (
         'm': ('mega', 1em, 'medium'),

--- a/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
+++ b/ckanext/datavic_odp_theme/webassets/datavic_odp_theme.css
@@ -1180,6 +1180,7 @@ nav {
     padding-left: 0; }
 
 .module .dashboard-header {
+  font-family: "VIC-Bold", "Arial", "Helvetica", "sans-serif";
   font-size: 1.5em;
   padding: 0px 15px 0px 30px; }
 
@@ -2168,12 +2169,12 @@ nav {
     @media screen and (min-width: 768px) {
       .rpl-search-form h1 {
         font-family: "VIC-Bold", "Arial", "Helvetica", "sans-serif";
-        font-size: 3rem;
+        font-size: 2rem;
         line-height: 1em; } }
     @media screen and (min-width: 1600px) {
       .rpl-search-form h1 {
         font-family: "VIC-Bold", "Arial", "Helvetica", "sans-serif";
-        font-size: 3.5rem;
+        font-size: 2rem;
         line-height: 1em; } }
     .rpl-search-form--dark h1 {
       color: #fff; }


### PR DESCRIPTION
- H1 font size is reduced to 2rem (from the current 3.5rem)
- Dataset Search page title: should read: “Search Y datasets“
- h1 title on “My Dashboard“ page uses VIC-Bold font