### PR TITLE
DATAVIC-916 Update dashboard links in header and user dashboard

### DIFF
--- a/ckanext/datavic_odp_theme/templates/header.html
+++ b/ckanext/datavic_odp_theme/templates/header.html
@@ -26,7 +26,7 @@
               {% set new_activities = h.new_activities() %}
               <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
                 {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities) %}
-                <a href="{{ h.url_for('activity.dashboard') }}" title="{{ notifications_tooltip }}">
+                <a href="{{ h.url_for('dashboard.datasets') }}" title="{{ notifications_tooltip }}">
                   <i class="fa fa-tachometer" aria-hidden="true"></i>
                   <span class="text">{{ _('Dashboard') }}</span>
                   <span class="badge">{{ new_activities }}</span>

--- a/ckanext/datavic_odp_theme/templates/user/dashboard.html
+++ b/ckanext/datavic_odp_theme/templates/user/dashboard.html
@@ -7,10 +7,8 @@
           {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn', icon='cog' %}
         </div>
         <ul class="nav nav-tabs">
-          {{ h.build_nav_icon('activity.dashboard', _('News feed')) }}
           {{ h.build_nav_icon('dashboard.datasets', _('My datasets')) }}
           {{ h.build_nav_icon('dashboard.organizations', _('My organizations')) }}
-          {{ h.build_nav_icon('dashboard.groups', _('My groups')) }}
         </ul>
       </div>
     {% endblock %}


### PR DESCRIPTION
This pull request updates the dashboard navigation and notification links to improve consistency and user experience. The main changes involve updating the notification link to point to the datasets dashboard and modifying the dashboard navigation tabs.

Dashboard navigation updates:

* The notification icon in `header.html` now links to the datasets dashboard (`dashboard.datasets`) instead of the activity dashboard (`activity.dashboard`).
* In `user/dashboard.html`, the "News feed" and "My groups" tabs have been removed from the dashboard navigation, leaving only "My datasets" and "My organisations".