### PR TITLE
DATAVIC-924 Updates to user profile page

### DIFF
--- a/ckanext/datavic_odp_theme/logic/__init__.py
+++ b/ckanext/datavic_odp_theme/logic/__init__.py
@@ -13,6 +13,7 @@ def auth_functions():
 
 def actions():
     return {
+        "user_update": action.user_update,
         "organization_update": action.organization_update,
         "package_update": action.package_update,
         "package_delete": action.package_delete,

--- a/ckanext/datavic_odp_theme/logic/action.py
+++ b/ckanext/datavic_odp_theme/logic/action.py
@@ -17,6 +17,18 @@ from ckanext.datavic_odp_theme import jobs
 
 
 @tk.chained_action
+def user_update(next_, context, data_dict):
+    """Non-sysadmins cannot change email via API or tampered forms; keep stored value."""
+    if not context.get("ignore_auth"):
+        cu = tk.current_user
+        if cu.is_authenticated and not getattr(cu, "sysadmin", False):
+            target = model.User.get(data_dict["id"])
+            if target is not None:
+                data_dict["email"] = target.email
+    return next_(context, data_dict)
+
+
+@tk.chained_action
 def organization_update(next_, context, data_dict):
     result = next_(context, data_dict)
     tk.enqueue_job(jobs.reindex_organization, [result["id"]])

--- a/ckanext/datavic_odp_theme/templates/user/edit_user_form.html
+++ b/ckanext/datavic_odp_theme/templates/user/edit_user_form.html
@@ -1,0 +1,34 @@
+{% ckan_extends %}
+
+{% import 'macros/form.html' as form %}
+
+{% block core_fields %}
+  <fieldset>
+    <legend>{{ _('Change details') }}</legend>
+    {% if g.userobj.sysadmin %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+    {% else %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+    {% endif %}
+
+    {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
+
+    {% if g.userobj.sysadmin %}
+      {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=true) }}
+    {% else %}
+      {% call form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=true, attrs={'readonly': '', 'class': 'form-control'}) %}
+        {% set email_help_html %}
+            To update your email address, please <a href="https://www.data.vic.gov.au/contact-us">contact us</a>.
+        {% endset %}
+        {{ form.info(text=email_help_html|safe) }}
+      {% endcall %}
+    {% endif %}
+
+    {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
+
+    {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+    {% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label=_('Profile picture'), url_label=_('Profile picture URL') ) }}
+  </fieldset>
+{% endblock %}

--- a/ckanext/datavic_odp_theme/templates/user/snippets/info.html
+++ b/ckanext/datavic_odp_theme/templates/user/snippets/info.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block user_nums %}
+<!-- Remove user numbers block -->
+{% endblock %}


### PR DESCRIPTION
This pull request introduces enhancements to user profile editing, focusing on restricting non-sysadmin users from changing their email addresses via the API or the web form, and improving the user interface for editing user details. It also customises the user information display by removing the user numbers block.

**User update restrictions and logic:**

* Added a new chained action `user_update` in `action.py` to prevent non-sysadmin users from changing their email address through the API or tampered forms; the stored email value is retained for such users.
* Registered the new `user_update` action in the `actions()` function to ensure it is available to the system.

**User profile form improvements:**

* Updated the `edit_user_form.html` template to make the email and username fields read-only for non-sysadmin users, and added a help message guiding users on how to update their email address.

**User info page customisation:**

* Extended the `user/snippets/info.html` template to remove the user numbers block from the user info display.