### PR TITLE
DATAVIC-930 Make activity stream accessible to authorised users

### DIFF
--- a/ckanext/datavic_odp_theme/logic/__init__.py
+++ b/ckanext/datavic_odp_theme/logic/__init__.py
@@ -8,6 +8,7 @@ def auth_functions():
         activity_list=get.vic_activity_list,
         package_activity_list=get.vic_package_activity_list,
         organization_activity_list=get.vic_organization_activity_list,
+        user_activity_list=get.vic_user_activity_list,
     )
 
 

--- a/ckanext/datavic_odp_theme/logic/action.py
+++ b/ckanext/datavic_odp_theme/logic/action.py
@@ -18,13 +18,19 @@ from ckanext.datavic_odp_theme import jobs
 
 @tk.chained_action
 def user_update(next_, context, data_dict):
-    """Non-sysadmins cannot change email via API or tampered forms; keep stored value."""
-    if not context.get("ignore_auth"):
-        cu = tk.current_user
-        if cu.is_authenticated and not getattr(cu, "sysadmin", False):
-            target = model.User.get(data_dict["id"])
-            if target is not None:
-                data_dict["email"] = target.email
+    """Lock email to the stored value for non-sysadmins (including reset-key)."""
+    # Sysadmins may set email from the request; leave data_dict unchanged.
+    if tk.current_user.is_authenticated and tk.current_user.sysadmin:
+        return next_(context, data_dict)
+
+    # Target user missing: defer to core (e.g. NotFound).
+    user_obj = model.User.get(data_dict.get("id"))
+    if user_obj is None:
+        return next_(context, data_dict)
+
+    # Ignore submitted email, keep the address already on the user row.
+    data_dict["email"] = user_obj.email
+
     return next_(context, data_dict)
 
 
@@ -161,7 +167,7 @@ def datavic_list_incomplete_resources(context, data_dict):
     missing_conditions = []
     for field in required_fields:
         model_attr = getattr(model.Resource, field)
-        missing_conditions.append(or_(model_attr == None, model_attr == ""))
+        missing_conditions.append(or_(model_attr.is_(None), model_attr == ""))
 
     q = (
         model.Session.query(model.Resource)

--- a/ckanext/datavic_odp_theme/logic/auth/get.py
+++ b/ckanext/datavic_odp_theme/logic/auth/get.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 from typing import Any
 
 import ckan.authz as authz
+import ckan.model as model
 import ckan.plugins.toolkit as tk
 
 
 @tk.chained_auth_function
+# Same as core ``activity_list``: allow the chain to run for anonymous users so
+# public group (and delegated show) checks can still apply; package/org anon is denied below.
 @tk.auth_allow_anonymous_access
 def vic_activity_list(next_auth, context, data_dict):
     """
@@ -41,9 +44,48 @@ def vic_activity_list(next_auth, context, data_dict):
     ):
         return {"success": False}
 
+    # Organisation activity: only org admins may view (anonymous already denied for org above).
+    if data_dict["object_type"] == "organization":
+        return {
+            "success": authz.has_user_permission_for_group_or_org(
+                data_dict["id"], tk.current_user.name, "admin"
+            )
+        }
+
     return authz.is_authorized(
         action_on_which_to_base_auth, context, {"id": data_dict["id"]}
     )
+
+
+@tk.chained_auth_function
+def vic_user_activity_list(next_auth, context, data_dict):
+    """Restrict user activity streams: self, or org admins for subject's orgs.
+
+    Anonymous requests are turned away in ``authz.is_authorized`` (no
+    ``auth_allow_anonymous_access`` on this function). Sysadmins are not
+    handled here: ``authz.is_authorized`` returns success for them before this
+    chained auth runs (unless the action uses ``auth_sysadmins_check``, which
+    ``user_activity_list`` does not).
+    """
+
+    user = model.User.get(data_dict.get("id"))
+    # Unknown user id or name: deny (matches action layer behaviour).
+    if not user:
+        return {"success": False}
+
+    # Users may always view their own activity stream.
+    if tk.current_user.id == user.id:
+        return {"success": True}
+
+    # Org admins may view activity for users who belong to an org they administer.
+    for org in user.get_groups(group_type="organization"):
+        if authz.has_user_permission_for_group_or_org(
+            org.id, tk.current_user.name, "admin"
+        ):
+            return {"success": True}
+
+    # No remaining rule applies (e.g. user is not admin of any org the subject is in).
+    return {"success": False}
 
 
 @tk.chained_auth_function


### PR DESCRIPTION
This pull request enhances user activity stream authorisation and tightens security for user email updates. The main changes introduce a new authorisation function for user activity streams, restrict access to these streams based on user roles, and refactor the user update logic to better enforce email immutability for non-sysadmins. There are also minor improvements to query conditions for resource completeness.

**Authorisation improvements:**

* Added a new `vic_user_activity_list` chained auth function to restrict access to user activity streams, allowing only the user themselves or organisation admins to view a user's activity; sysadmins are handled by core logic.
* Registered the new `user_activity_list` auth function in the `auth_functions` mapping.
* Updated `vic_activity_list` to explicitly restrict organisation activity streams to organisation admins.

**User update and data protection:**

* Refactored the `user_update` action to ensure non-sysadmins cannot change their email address, even via API or tampered forms; sysadmins retain this ability.

**Code quality and correctness:**

* Improved the query for incomplete resources by using `is_(None)` for null checks, aligning with SQLAlchemy best practices.
* Added missing import for `ckan.model` in the `get.py` auth module.