### PR TITLE
[DATAVIC-951] fix typo and update header url

### DIFF
--- a/ckanext/datavic_odp_theme/helpers.py
+++ b/ckanext/datavic_odp_theme/helpers.py
@@ -377,8 +377,8 @@ def get_header_structure(userobj: model.User | None) -> list[dict[str, Any]]:
             ],
         },
         {
-            "title": toolkit._("User guide"),
-            "url": "/pages/user-guides",
+            "title": toolkit._("Data publishing guide"),
+            "url": "https://www.data.vic.gov.au/data-publishing-guide",
         },
         {
             "title": toolkit._("Search data"),

--- a/ckanext/datavic_odp_theme/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/datavic_odp_theme/templates/scheming/package/snippets/package_form.html
@@ -26,10 +26,10 @@
                 <a href="https://ovic.vic.gov.au/information-security/framework-vpdsf" target="_blank">Victorian Protective Data Security Framework</a> and <a href="https://ovic.vic.gov.au/information-security/standards" target="_blank">Standards</a>
             </li>
             <li>
-                your organisation's own data governance policies
+                Your organisation's own data governance policies
             </li>
         </ul>
         <p>DataVic does not check your organisation's compliance with these obligations.</p>
     </div>
     {{ super() }}
-{% endblock %}}
+{% endblock %}

--- a/ckanext/datavic_odp_theme/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/datavic_odp_theme/templates/scheming/package/snippets/package_form.html
@@ -10,7 +10,7 @@
         <p>
             <strong>Disclaimer</strong><br/>
             Your organisation is responsible for all data and metadata you publish on DataVic.<br/>
-            You organisation is bound by:
+            Your organisation is bound by:
         </p>
         <ul>
             <li>


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DATAVIC-915

updated the menu and its link.