### PR TITLE
Release: 2.10.10 – point of contact & login eligibility

### DIFF
--- a/ckanext/datavic_odp_theme/templates/user/login.html
+++ b/ckanext/datavic_odp_theme/templates/user/login.html
@@ -2,12 +2,12 @@
 
 {% block primary_content %}
   {{ super() }}
-  
+
   <section class="module">
     <div class="module-content">
       <p>
-        {{ _('DataVic login access is limited to local councils and water authorities.') }}</br>
-        {{ _('If you\'re part of the Victorian Public Service (VPS), please manage your data through the <a href="https://directory.data.vic.gov.au/" target="_blank">VPS Data Directory</a>.') }}
+        {{ _('DataVic login access is limited to local councils and water authorities.') }}<br>
+        {% trans %}If you're part of the Victorian Public Service (VPS), please manage your data through the <a href="https://directory.data.vic.gov.au/" target="_blank">VPS Data Directory</a>.{% endtrans %}
       </p>
     </div>
   </section>

--- a/ckanext/datavic_odp_theme/templates/user/login.html
+++ b/ckanext/datavic_odp_theme/templates/user/login.html
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+
+{% block primary_content %}
+  {{ super() }}
+  
+  <section class="module">
+    <div class="module-content">
+      <p>
+        {{ _('DataVic login access is limited to local councils and water authorities.') }}</br>
+        {{ _('If you\'re part of the Victorian Public Service (VPS), please manage your data through the <a href="https://directory.data.vic.gov.au/" target="_blank">VPS Data Directory</a>.') }}
+      </p>
+    </div>
+  </section>
+{% endblock %}


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-974](https://digital-vic.atlassian.net/browse/DATAVIC-974) — Add eligibility notice to DV login page**
- Adds `templates/user/login.html` extending core login: notice that DataVic login is limited to local councils and water authorities, with a translatable link to the VPS Data Directory

[DATAVIC-974]: https://digital-vic.atlassian.net/browse/DATAVIC-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ